### PR TITLE
get_token will set quiet to False ...

### DIFF
--- a/user.py
+++ b/user.py
@@ -24,7 +24,7 @@ class User:
         self.quiet = quiet
         self.header["Authorization"] = self.get_token(self.quiet)
     
-    def get_token(self, quiet):
+    def get_token(self, quiet=False):
         """
             Request auth endpoint and return user token  
         """


### PR DESCRIPTION
get_token will set quiet to False as long as it is not explicitly set to true. 

If you try to download a larger set of books (I have a library of 1200 packtpub books and videos), a header_refresh will be triggered. However, header_refresh does not send the quiet boolean (as well as every other method using header_refresh().

As a quick fix, ensure that quiet is at least False when not set explicitly 